### PR TITLE
Fix Search Console indexing signals

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -16,7 +16,9 @@ export default defineConfig({
   site: SITE.website,
   integrations: [
     sitemap({
-      filter: page => SITE.showArchives || !page.endsWith("/archives"),
+      filter: page =>
+        SITE.showArchives ||
+        !page.replace(/\/$/, "").endsWith("/archives"),
     }),
   ],
   markdown: {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,7 +6,13 @@ import LinkButton from "@/components/LinkButton.astro";
 import { SITE } from "@/config";
 ---
 
-<Layout title={`404 Not Found | ${SITE.title}`}>
+<Layout
+  title={`404 Not Found | ${SITE.title}`}
+  canonicalURL={new URL("/404", SITE.website).toString()}
+>
+  <Fragment slot="head">
+    <meta name="robots" content="noindex" />
+  </Fragment>
   <Header />
 
   <main


### PR DESCRIPTION
## Summary
- remove the hidden archives page from the sitemap
- point the 404 page canonical to `/404`
- add `noindex` to the 404 page

## Why
Google Search Console reported new indexing issues for `juanibiapina.dev`. This fixes the two likely causes: a sitemap entry for `/archives/` that redirects to `/404`, and a 404 page canonical that pointed at `/404/`.

## Testing
- npm run build